### PR TITLE
fix(cli): correct issue action message for close/reopen

### DIFF
--- a/crates/grite-daemon/src/worker.rs
+++ b/crates/grite-daemon/src/worker.rs
@@ -325,6 +325,7 @@ fn execute_command_inner(
             let projection = IssueProjection::from_event(&event)?;
             let mut json_val = projection_to_json(&projection);
             json_val["event_id"] = serde_json::Value::String(id_to_hex(&event_id));
+            json_val["action"] = serde_json::Value::String(libgrite_ipc::issue_action::CREATED.to_string());
             let json = serde_json::to_string(&json_val)?;
             Ok(Some(json))
         }
@@ -398,6 +399,7 @@ fn execute_command_inner(
                 "issue_id": issue_id,
                 "event_id": id_to_hex(&event_id),
                 "state": "closed",
+                "action": libgrite_ipc::issue_action::CLOSED,
             }))?;
             Ok(Some(json))
         }
@@ -420,6 +422,7 @@ fn execute_command_inner(
                 "issue_id": issue_id,
                 "event_id": id_to_hex(&event_id),
                 "state": "open",
+                "action": libgrite_ipc::issue_action::REOPENED,
             }))?;
             Ok(Some(json))
         }

--- a/crates/grite/src/main.rs
+++ b/crates/grite/src/main.rs
@@ -135,10 +135,15 @@ fn output_daemon_data(cli: &Cli, data: &str) -> Result<(), GriteError> {
                     println!("{} [{}] {}", &id[..8.min(id.len())], state, title);
                 }
             }
-        } else if json.get("issue_id").is_some() && json.get("event_id").is_some() {
-            // Issue created response (has both issue_id and event_id)
+        } else if let Some(action) = json.get("action").and_then(|v| v.as_str()) {
             let issue_id = json.get("issue_id").and_then(|v| v.as_str()).unwrap_or("?");
-            println!("Created issue {}", issue_id);
+            let action_str = match action {
+                libgrite_ipc::issue_action::CREATED => "Created",
+                libgrite_ipc::issue_action::CLOSED => "Closed",
+                libgrite_ipc::issue_action::REOPENED => "Reopened",
+                _ => action,
+            };
+            println!("{} issue {}", action_str, issue_id);
         } else if json.get("issue_id").is_some() && json.get("title").is_some() {
             // Issue show response
             let id = json.get("issue_id").and_then(|v| v.as_str()).unwrap_or("?");

--- a/crates/libgrite-ipc/src/lib.rs
+++ b/crates/libgrite-ipc/src/lib.rs
@@ -32,3 +32,10 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 
 /// Default lease duration for daemon locks in milliseconds
 pub const DEFAULT_LEASE_MS: u64 = 30_000;
+
+/// Issue action types returned in daemon responses
+pub mod issue_action {
+    pub const CREATED: &str = "created";
+    pub const CLOSED: &str = "closed";
+    pub const REOPENED: &str = "reopened";
+}


### PR DESCRIPTION
The CLI incorrectly showed "Created issue" for close and reopen operations. Now it distinguishes between:

- state="closed" → "Closed issue"
- state="open" without title → "Reopened issue"
- state="open" with title → "Created issue"