### PR TITLE
Chore - spelling updates "grit" --> "grite"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ memista.*
 *.env
 ~/
 
-# Grit data (development artifacts)
-.grit/
+# Grite data (development artifacts)
+.grite/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 Grit stores data in git refs and a local sled database. When using Grit, consider:
 
-- **Git repository access**: Anyone with read access to the git repository can read the Grit event log
+- **Git repository access**: Anyone with read access to the git repository can read the grite event log
 - **Ed25519 signing**: Enable signing for event authenticity verification
 - **Local database**: The sled database is stored in `.git/grite/` and contains materialized views of the event log
 - **Daemon IPC**: The daemon uses local IPC sockets for communication

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 ### Security Considerations
 
-Grit stores data in git refs and a local sled database. When using Grit, consider:
+Grit stores data in git refs and a local sled database. When using grite, consider:
 
 - **Git repository access**: Anyone with read access to the git repository can read the grite event log
 - **Ed25519 signing**: Enable signing for event authenticity verification

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 ### Security Considerations
 
-Grit stores data in git refs and a local sled database. When using grite, consider:
+Grite stores data in git refs and a local sled database. When using grite, consider:
 
 - **Git repository access**: Anyone with read access to the git repository can read the grite event log
 - **Ed25519 signing**: Enable signing for event authenticity verification

--- a/crates/grite-bench/src/bench/runner.rs
+++ b/crates/grite-bench/src/bench/runner.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 
-use libgrite_core::store::{GritStore, LockedStore};
+use libgrite_core::store::{GriteStore, LockedStore};
 use libgrite_git::WalManager;
 
 use super::agent::SimulatedAgent;
@@ -246,7 +246,7 @@ fn setup_repository(config: &BenchmarkConfig) -> Result<(PathBuf, LockedStore)> 
 
     // Open locked store
     let sled_path = data_dir.join("sled");
-    let store = GritStore::open_locked_blocking(&sled_path, Duration::from_secs(30))
+    let store = GriteStore::open_locked_blocking(&sled_path, Duration::from_secs(30))
         .map_err(|e| BenchError::Bench(format!("Failed to open store: {}", e)))?;
 
     Ok((git_dir, store))

--- a/crates/grite-daemon/src/error.rs
+++ b/crates/grite-daemon/src/error.rs
@@ -13,7 +13,7 @@ pub enum DaemonError {
     #[error("Failed to acquire lock: {0}")]
     LockFailed(String),
 
-    /// Core grit error
+    /// Core grite error
     #[error("Grit error: {0}")]
     Grit(#[from] libgrite_core::GriteError),
 

--- a/crates/grite-daemon/src/error.rs
+++ b/crates/grite-daemon/src/error.rs
@@ -14,7 +14,7 @@ pub enum DaemonError {
     LockFailed(String),
 
     /// Core grite error
-    #[error("Grit error: {0}")]
+    #[error("grite error: {0}")]
     Grit(#[from] libgrite_core::GriteError),
 
     /// Git error

--- a/crates/grite-daemon/src/error.rs
+++ b/crates/grite-daemon/src/error.rs
@@ -15,7 +15,7 @@ pub enum DaemonError {
 
     /// Core grite error
     #[error("grite error: {0}")]
-    Grit(#[from] libgrite_core::GriteError),
+    Core(#[from] libgrite_core::GriteError),
 
     /// Git error
     #[error("Git error: {0}")]

--- a/crates/grite-daemon/src/worker.rs
+++ b/crates/grite-daemon/src/worker.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use libgrite_core::types::ids::{hex_to_id, ActorId};
-use libgrite_core::{GriteError, GritStore, LockedStore};
+use libgrite_core::{GriteError, GriteStore, LockedStore};
 use libgrite_core::store::IssueFilter;
 use libgrite_ipc::{DaemonLock, IpcCommand, IpcResponse, Notification};
 use tokio::sync::mpsc;
@@ -74,11 +74,11 @@ impl Worker {
 
         // Parse actor ID
         let actor_id_bytes = hex_to_id(&actor_id)
-            .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+            .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
 
         // Open store with filesystem lock (blocking with timeout)
         // This ensures exclusive process-level access to the sled database
-        let store = Arc::new(GritStore::open_locked_blocking(
+        let store = Arc::new(GriteStore::open_locked_blocking(
             &sled_path,
             Duration::from_secs(5),
         )?);
@@ -300,9 +300,9 @@ fn execute_command_inner(
 
         IpcCommand::IssueShow { issue_id } => {
             let id = store.resolve_issue_id(issue_id)
-                .map_err(|e| DaemonError::Grit(e))?;
+                .map_err(|e| DaemonError::Core(e))?;
             let p = store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let json = serde_json::to_string(&projection_to_json(&p))?;
             Ok(Some(json))
@@ -332,15 +332,15 @@ fn execute_command_inner(
 
         IpcCommand::IssueUpdate { issue_id, title, body } => {
             if title.is_none() && body.is_none() {
-                return Err(DaemonError::Grit(GriteError::InvalidArgs(
+                return Err(DaemonError::Core(GriteError::InvalidArgs(
                     "At least one of title or body must be provided".to_string()
                 )));
             }
 
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let ts = current_time_ms();
             let kind = EventKind::IssueUpdated {
@@ -362,9 +362,9 @@ fn execute_command_inner(
 
         IpcCommand::IssueComment { issue_id, body } => {
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let ts = current_time_ms();
             let kind = EventKind::CommentAdded { body: body.clone() };
@@ -383,9 +383,9 @@ fn execute_command_inner(
 
         IpcCommand::IssueClose { issue_id } => {
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let ts = current_time_ms();
             let kind = EventKind::StateChanged { state: IssueState::Closed };
@@ -406,9 +406,9 @@ fn execute_command_inner(
 
         IpcCommand::IssueReopen { issue_id } => {
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let ts = current_time_ms();
             let kind = EventKind::StateChanged { state: IssueState::Open };
@@ -429,9 +429,9 @@ fn execute_command_inner(
 
         IpcCommand::IssueLabel { issue_id, add, remove } => {
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let mut event_ids = Vec::new();
             let ts = current_time_ms();
@@ -463,9 +463,9 @@ fn execute_command_inner(
 
         IpcCommand::IssueAssign { issue_id, add, remove } => {
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let mut event_ids = Vec::new();
             let ts = current_time_ms();
@@ -497,9 +497,9 @@ fn execute_command_inner(
 
         IpcCommand::IssueLink { issue_id, url, note } => {
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let ts = current_time_ms();
             let kind = EventKind::LinkAdded {
@@ -521,20 +521,20 @@ fn execute_command_inner(
 
         IpcCommand::IssueAttach { issue_id, file_path } => {
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
 
             let parts: Vec<&str> = file_path.splitn(3, ':').collect();
             if parts.len() != 3 {
-                return Err(DaemonError::Grit(GriteError::InvalidArgs(
+                return Err(DaemonError::Core(GriteError::InvalidArgs(
                     "file_path must be in format 'name:sha256:mime'".to_string()
                 )));
             }
 
             let name = parts[0].to_string();
             let sha256: [u8; 32] = hex_to_id(parts[1])
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             let mime = parts[2].to_string();
 
             let ts = current_time_ms();
@@ -584,7 +584,7 @@ fn execute_command_inner(
                     serde_json::to_string(&export)?
                 }
                 "md" | "markdown" => export_markdown(store, since_opt)?,
-                _ => return Err(DaemonError::Grit(GriteError::InvalidArgs(
+                _ => return Err(DaemonError::Core(GriteError::InvalidArgs(
                     format!("Unknown format: {}", format)
                 ))),
             };
@@ -597,20 +597,20 @@ fn execute_command_inner(
             use libgrite_core::types::ids::id_to_hex;
 
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             let target = hex_to_id(target_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             let dep = DependencyType::from_str(dep_type).ok_or_else(|| {
-                DaemonError::Grit(GriteError::InvalidArgs(format!("Invalid dep type: {}", dep_type)))
+                DaemonError::Core(GriteError::InvalidArgs(format!("Invalid dep type: {}", dep_type)))
             })?;
 
             store.get_issue(&id)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Issue {} not found", issue_id))))?;
             store.get_issue(&target)?
-                .ok_or_else(|| DaemonError::Grit(GriteError::NotFound(format!("Target {} not found", target_id))))?;
+                .ok_or_else(|| DaemonError::Core(GriteError::NotFound(format!("Target {} not found", target_id))))?;
 
             if store.would_create_cycle(&id, &target, &dep)? {
-                return Err(DaemonError::Grit(GriteError::InvalidArgs(format!(
+                return Err(DaemonError::Core(GriteError::InvalidArgs(format!(
                     "Adding this dependency would create a cycle in the {} graph", dep.as_str()
                 ))));
             }
@@ -638,11 +638,11 @@ fn execute_command_inner(
             use libgrite_core::types::ids::id_to_hex;
 
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             let target = hex_to_id(target_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             let dep = DependencyType::from_str(dep_type).ok_or_else(|| {
-                DaemonError::Grit(GriteError::InvalidArgs(format!("Invalid dep type: {}", dep_type)))
+                DaemonError::Core(GriteError::InvalidArgs(format!("Invalid dep type: {}", dep_type)))
             })?;
 
             let ts = current_time_ms();
@@ -666,7 +666,7 @@ fn execute_command_inner(
             use libgrite_core::types::ids::id_to_hex;
 
             let id = hex_to_id(issue_id)
-                .map_err(|e| DaemonError::Grit(GriteError::InvalidArgs(e.to_string())))?;
+                .map_err(|e| DaemonError::Core(GriteError::InvalidArgs(e.to_string())))?;
             let deps = if *reverse {
                 store.get_dependents(&id)?
             } else {
@@ -789,7 +789,7 @@ fn execute_command_inner(
         }
 
         IpcCommand::SnapshotCreate | IpcCommand::SnapshotList | IpcCommand::SnapshotGc { .. } => {
-            Err(DaemonError::Grit(GriteError::Internal(
+            Err(DaemonError::Core(GriteError::Internal(
                 "Snapshot through daemon not yet implemented - use --no-daemon".to_string()
             )))
         }
@@ -851,9 +851,9 @@ fn error_to_code_message(e: &DaemonError) -> (String, String) {
     use libgrite_ipc::error::codes;
 
     match e {
-        DaemonError::Grit(GriteError::NotFound(_)) => (codes::NOT_FOUND.to_string(), e.to_string()),
-        DaemonError::Grit(GriteError::InvalidArgs(_)) => (codes::INVALID_INPUT.to_string(), e.to_string()),
-        DaemonError::Grit(GriteError::Io(_)) => (codes::IO_ERROR.to_string(), e.to_string()),
+        DaemonError::Core(GriteError::NotFound(_)) => (codes::NOT_FOUND.to_string(), e.to_string()),
+        DaemonError::Core(GriteError::InvalidArgs(_)) => (codes::INVALID_INPUT.to_string(), e.to_string()),
+        DaemonError::Core(GriteError::Io(_)) => (codes::IO_ERROR.to_string(), e.to_string()),
         DaemonError::Git(_) => (codes::GIT_ERROR.to_string(), e.to_string()),
         DaemonError::Ipc(_) | DaemonError::Nng(_) => (codes::IPC_ERROR.to_string(), e.to_string()),
         _ => (codes::INTERNAL.to_string(), e.to_string()),

--- a/crates/grite-daemon/tests/integration_tests.rs
+++ b/crates/grite-daemon/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-//! Integration tests for grit-daemon daemon
+//! Integration tests for grite-daemon daemon
 
 use std::time::Duration;
 

--- a/crates/grite/src/agents_md.rs
+++ b/crates/grite/src/agents_md.rs
@@ -1,5 +1,5 @@
 /// Template content for the Grite section in AGENTS.md
-pub const GRIT_AGENTS_SECTION: &str = r#"## Grite
+pub const GRITE_AGENTS_SECTION: &str = r#"## Grite
 
 This repository uses **Grite** as the canonical task and memory system. **Always use grite commands** (not git) for task/issue tracking.
 

--- a/crates/grite/src/commands/init.rs
+++ b/crates/grite/src/commands/init.rs
@@ -7,7 +7,7 @@ use libgrite_core::{
 use serde::Serialize;
 use std::fs;
 use std::path::PathBuf;
-use crate::agents_md::GRIT_AGENTS_SECTION;
+use crate::agents_md::GRITE_AGENTS_SECTION;
 use crate::cli::Cli;
 use crate::context::GriteContext;
 use crate::output::{output_success, print_human};
@@ -124,9 +124,9 @@ fn handle_agents_md(git_dir: &PathBuf) -> Result<(Option<PathBuf>, AgentsMdActio
 
         // Append grite section
         let new_content = if content.ends_with('\n') {
-            format!("{}\n{}", content, GRIT_AGENTS_SECTION)
+            format!("{}\n{}", content, GRITE_AGENTS_SECTION)
         } else {
-            format!("{}\n\n{}", content, GRIT_AGENTS_SECTION)
+            format!("{}\n\n{}", content, GRITE_AGENTS_SECTION)
         };
 
         fs::write(&agents_md_path, new_content).map_err(|e| {
@@ -136,7 +136,7 @@ fn handle_agents_md(git_dir: &PathBuf) -> Result<(Option<PathBuf>, AgentsMdActio
         Ok((Some(agents_md_path), AgentsMdAction::Updated))
     } else {
         // Create new AGENTS.md
-        fs::write(&agents_md_path, GRIT_AGENTS_SECTION).map_err(|e| {
+        fs::write(&agents_md_path, GRITE_AGENTS_SECTION).map_err(|e| {
             GriteError::Internal(format!("Failed to create AGENTS.md: {}", e))
         })?;
 

--- a/crates/grite/src/commands/init.rs
+++ b/crates/grite/src/commands/init.rs
@@ -2,7 +2,7 @@ use libgrite_core::{
     config::{save_repo_config, save_actor_config, actor_dir, RepoConfig},
     types::actor::ActorConfig,
     types::ids::{generate_actor_id, id_to_hex},
-    GritStore, GriteError,
+    GriteStore, GriteError,
 };
 use serde::Serialize;
 use std::fs;
@@ -57,7 +57,7 @@ pub fn run(cli: &Cli, no_agents_md: bool) -> Result<(), GriteError> {
 
     // Initialize empty sled database with lock
     let sled_path = data_dir.join("sled");
-    let _store = GritStore::open_locked(&sled_path)?;
+    let _store = GriteStore::open_locked(&sled_path)?;
 
     // Set repo default
     let repo_config = RepoConfig {

--- a/crates/grite/src/commands/init.rs
+++ b/crates/grite/src/commands/init.rs
@@ -118,7 +118,7 @@ fn handle_agents_md(git_dir: &PathBuf) -> Result<(Option<PathBuf>, AgentsMdActio
         })?;
 
         // Check if grite section already exists
-        if content.contains("## Grit") {
+        if content.contains("## Grite") {
             return Ok((Some(agents_md_path), AgentsMdAction::Skipped));
         }
 

--- a/crates/grite/src/context.rs
+++ b/crates/grite/src/context.rs
@@ -63,7 +63,7 @@ impl std::fmt::Debug for ExecutionMode {
     }
 }
 
-/// Resolved context for a grit command
+/// Resolved context for a grite command
 pub struct GriteContext {
     pub git_dir: PathBuf,
     pub actor_id: String,

--- a/crates/grite/src/context.rs
+++ b/crates/grite/src/context.rs
@@ -8,7 +8,7 @@ use libgrite_core::{
     types::actor::ActorConfig,
     types::event::Event,
     types::ids::{generate_actor_id, id_to_hex},
-    GritStore, LockedStore, GriteError,
+    GriteStore, LockedStore, GriteError,
 };
 use libgrite_git::{WalManager, SnapshotManager, SyncManager, LockManager, GitError};
 use libgrite_ipc::{DaemonLock, IpcClient};
@@ -212,7 +212,7 @@ impl GriteContext {
     /// Returns `GriteError::DbBusy` if another process holds the lock.
     pub fn open_store(&self) -> Result<LockedStore, GriteError> {
         let sled_path = self.data_dir.join("sled");
-        GritStore::open_locked(&sled_path)
+        GriteStore::open_locked(&sled_path)
     }
 
     /// Get the sled database path

--- a/crates/grite/src/event_helper.rs
+++ b/crates/grite/src/event_helper.rs
@@ -3,7 +3,7 @@
 use libgrite_core::{
     types::event::Event,
     types::ids::ActorId,
-    GritStore, GriteError,
+    GriteStore, GriteError,
 };
 use libgrite_git::{WalManager, GitError};
 
@@ -22,7 +22,7 @@ pub struct InsertResult {
 /// If WAL append fails, the event is still persisted in sled and
 /// an error is logged but not returned.
 pub fn insert_and_append(
-    store: &GritStore,
+    store: &GriteStore,
     wal: &WalManager,
     actor: &ActorId,
     event: &Event,

--- a/crates/libgrite-core/src/context/mod.rs
+++ b/crates/libgrite-core/src/context/mod.rs
@@ -9,7 +9,7 @@ use crate::types::ids::IssueId;
 /// This allows context events to flow through the standard event pipeline.
 pub fn context_issue_id(path: &str) -> IssueId {
     let mut hasher = Blake2b::<U16>::new();
-    hasher.update(b"grit:context:file:");
+    hasher.update(b"grite:context:file:");
     hasher.update(path.as_bytes());
     hasher.finalize().into()
 }

--- a/crates/libgrite-core/src/error.rs
+++ b/crates/libgrite-core/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-/// Main error type for grit operations
+/// Main error type for grite operations
 #[derive(Debug, Error)]
 pub enum GriteError {
     #[error("invalid arguments: {0}")]
@@ -79,32 +79,32 @@ impl GriteError {
         match self {
             GriteError::NotFound(msg) => {
                 if msg.contains("issue") || msg.starts_with("Issue") {
-                    vec!["Run 'grit issue list' to see available issues"]
+                    vec!["Run 'grite issue list' to see available issues"]
                 } else if msg.contains("actor") {
-                    vec!["Run 'grit actor init' to create an actor"]
+                    vec!["Run 'grite actor init' to create an actor"]
                 } else {
                     vec![]
                 }
             }
             GriteError::DbBusy(_) => vec![
-                "Try 'grit --no-daemon <command>' to bypass the daemon",
+                "Try 'grite --no-daemon <command>' to bypass the daemon",
                 "Or wait for the other process to finish",
-                "Or run 'grit daemon stop' to stop the daemon",
+                "Or run 'grite daemon stop' to stop the daemon",
             ],
             GriteError::Sled(_) => vec![
-                "Run 'grit doctor --fix' to rebuild the database",
+                "Run 'grite doctor --fix' to rebuild the database",
                 "If problem persists, check disk space and permissions",
             ],
             GriteError::Ipc(_) => vec![
-                "Run 'grit daemon stop' and retry",
-                "Or use 'grit --no-daemon <command>' to bypass IPC",
+                "Run 'grite daemon stop' and retry",
+                "Or use 'grite --no-daemon <command>' to bypass IPC",
             ],
             GriteError::Conflict(_) => vec![
-                "Run 'grit sync' to pull latest changes",
+                "Run 'grite sync' to pull latest changes",
             ],
             GriteError::IdParse(_) => vec![
                 "IDs should be hex strings (e.g., 'abc123...')",
-                "Use 'grit issue list' to see valid issue IDs",
+                "Use 'grite issue list' to see valid issue IDs",
             ],
             _ => vec![],
         }

--- a/crates/libgrite-core/src/export.rs
+++ b/crates/libgrite-core/src/export.rs
@@ -246,7 +246,7 @@ pub fn export_json(store: &GritStore, since: Option<ExportSince>) -> Result<Json
 pub fn export_markdown(store: &GritStore, _since: Option<ExportSince>) -> Result<String, GriteError> {
     let mut md = String::new();
 
-    md.push_str("# Grit Export\n\n");
+    md.push_str("# grite Export\n\n");
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -359,7 +359,7 @@ mod tests {
         store.insert_event(&event).unwrap();
 
         let md = export_markdown(&store, None).unwrap();
-        assert!(md.contains("# Grit Export"));
+        assert!(md.contains("# grite Export"));
         assert!(md.contains("Test Issue"));
         assert!(md.contains("bug"));
     }

--- a/crates/libgrite-core/src/export.rs
+++ b/crates/libgrite-core/src/export.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use crate::error::GriteError;
-use crate::store::{GritStore, IssueFilter};
+use crate::store::{GriteStore, IssueFilter};
 use crate::types::event::{Event, EventKind};
 use crate::types::ids::{id_to_hex, EventId};
 use crate::types::issue::IssueSummary;
@@ -197,7 +197,7 @@ pub enum ExportSince {
 }
 
 /// Export to JSON format
-pub fn export_json(store: &GritStore, since: Option<ExportSince>) -> Result<JsonExport, GriteError> {
+pub fn export_json(store: &GriteStore, since: Option<ExportSince>) -> Result<JsonExport, GriteError> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -243,7 +243,7 @@ pub fn export_json(store: &GritStore, since: Option<ExportSince>) -> Result<Json
 }
 
 /// Export to Markdown format
-pub fn export_markdown(store: &GritStore, _since: Option<ExportSince>) -> Result<String, GriteError> {
+pub fn export_markdown(store: &GriteStore, _since: Option<ExportSince>) -> Result<String, GriteError> {
     let mut md = String::new();
 
     md.push_str("# grite Export\n\n");
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn test_export_json() {
         let dir = tempdir().unwrap();
-        let store = GritStore::open(dir.path()).unwrap();
+        let store = GriteStore::open(dir.path()).unwrap();
 
         let issue_id = generate_issue_id();
         let actor = [1u8; 16];
@@ -345,7 +345,7 @@ mod tests {
     #[test]
     fn test_export_markdown() {
         let dir = tempdir().unwrap();
-        let store = GritStore::open(dir.path()).unwrap();
+        let store = GriteStore::open(dir.path()).unwrap();
 
         let issue_id = generate_issue_id();
         let actor = [1u8; 16];

--- a/crates/libgrite-core/src/hash.rs
+++ b/crates/libgrite-core/src/hash.rs
@@ -54,7 +54,7 @@ pub fn build_canonical_cbor(
 }
 
 /// Convert EventKind to (tag, payload) for CBOR encoding
-/// This is public so libgrit-git can use it for chunk encoding
+/// This is public so libgrite-git can use it for chunk encoding
 pub fn kind_to_tag_and_payload(kind: &EventKind) -> (u32, ciborium::Value) {
     match kind {
         EventKind::IssueCreated { title, body, labels } => {

--- a/crates/libgrite-core/src/integrity.rs
+++ b/crates/libgrite-core/src/integrity.rs
@@ -4,7 +4,7 @@
 
 use crate::hash::compute_event_id;
 use crate::signing::verify_signature;
-use crate::store::GritStore;
+use crate::store::GriteStore;
 use crate::types::event::Event;
 use crate::types::ids::{EventId, id_to_hex};
 use crate::GriteError;
@@ -99,7 +99,7 @@ pub fn verify_event_hash(event: &Event) -> Result<(), CorruptionKind> {
 /// - Event IDs match computed hashes
 /// - Parent references point to existing events (optional)
 pub fn check_store_integrity(
-    store: &GritStore,
+    store: &GriteStore,
     verify_parents: bool,
 ) -> Result<IntegrityReport, GriteError> {
     let mut report = IntegrityReport::default();
@@ -154,7 +154,7 @@ pub fn check_store_integrity(
 ///
 /// Requires a function to look up public keys by actor ID.
 pub fn verify_store_signatures<F>(
-    store: &GritStore,
+    store: &GriteStore,
     get_public_key: F,
 ) -> Result<IntegrityReport, GriteError>
 where

--- a/crates/libgrite-core/src/lib.rs
+++ b/crates/libgrite-core/src/lib.rs
@@ -15,7 +15,7 @@ pub use types::{ActorId, EventId, IssueId};
 pub use types::event::{Event, EventKind, IssueState};
 pub use types::issue::{IssueProjection, IssueSummary};
 pub use types::actor::ActorConfig;
-pub use store::{GritStore, LockedStore};
+pub use store::{GriteStore, LockedStore};
 pub use config::{RepoConfig, load_repo_config, save_repo_config, load_signing_key};
 pub use lock::{Lock, LockPolicy, LockCheckResult, LockStatus, resource_hash, DEFAULT_LOCK_TTL_MS};
 pub use signing::{SigningKeyPair, VerificationPolicy, SigningError, verify_signature};

--- a/crates/libgrite-core/src/lock.rs
+++ b/crates/libgrite-core/src/lock.rs
@@ -1,6 +1,6 @@
 //! Lock types for team coordination
 //!
-//! Grit uses lease-based locks stored as git refs for coordination.
+//! grite uses lease-based locks stored as git refs for coordination.
 //! Locks are optional and designed for coordination, not enforcement.
 
 use serde::{Deserialize, Serialize};

--- a/crates/libgrite-core/src/store/mod.rs
+++ b/crates/libgrite-core/src/store/mod.rs
@@ -49,7 +49,7 @@ pub struct RebuildStats {
     pub issue_count: usize,
 }
 
-/// A GritStore with filesystem-level exclusive lock.
+/// A GriteStore with filesystem-level exclusive lock.
 ///
 /// The lock is held for the lifetime of this struct and automatically
 /// released when dropped. This prevents multiple processes from opening
@@ -58,26 +58,26 @@ pub struct LockedStore {
     /// Lock file handle - flock released on drop
     _lock_file: File,
     /// The underlying store
-    store: GritStore,
+    store: GriteStore,
 }
 
 impl std::fmt::Debug for LockedStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LockedStore")
-            .field("store", &"GritStore { ... }")
+            .field("store", &"GriteStore { ... }")
             .finish()
     }
 }
 
 impl LockedStore {
-    /// Get a reference to the inner GritStore
-    pub fn inner(&self) -> &GritStore {
+    /// Get a reference to the inner GriteStore
+    pub fn inner(&self) -> &GriteStore {
         &self.store
     }
 }
 
 impl std::ops::Deref for LockedStore {
-    type Target = GritStore;
+    type Target = GriteStore;
 
     fn deref(&self) -> &Self::Target {
         &self.store
@@ -91,7 +91,7 @@ impl std::ops::DerefMut for LockedStore {
 }
 
 /// Main storage interface backed by sled
-pub struct GritStore {
+pub struct GriteStore {
     db: sled::Db,
     events: sled::Tree,
     issue_states: sled::Tree,
@@ -105,7 +105,7 @@ pub struct GritStore {
     context_project: sled::Tree,
 }
 
-impl GritStore {
+impl GriteStore {
     /// Open or create a store at the given path
     pub fn open(path: &Path) -> Result<Self, GriteError> {
         let db = sled::open(path)?;
@@ -1039,7 +1039,7 @@ mod tests {
     #[test]
     fn test_store_basic_operations() {
         let dir = tempdir().unwrap();
-        let store = GritStore::open(dir.path()).unwrap();
+        let store = GriteStore::open(dir.path()).unwrap();
 
         let issue_id = generate_issue_id();
         let actor = [1u8; 16];
@@ -1071,7 +1071,7 @@ mod tests {
     #[test]
     fn test_store_list_issues() {
         let dir = tempdir().unwrap();
-        let store = GritStore::open(dir.path()).unwrap();
+        let store = GriteStore::open(dir.path()).unwrap();
 
         let actor = [1u8; 16];
 
@@ -1098,7 +1098,7 @@ mod tests {
     #[test]
     fn test_store_rebuild() {
         let dir = tempdir().unwrap();
-        let store = GritStore::open(dir.path()).unwrap();
+        let store = GriteStore::open(dir.path()).unwrap();
 
         let issue_id = generate_issue_id();
         let actor = [1u8; 16];
@@ -1154,7 +1154,7 @@ mod tests {
         assert!(!lock_path.exists());
 
         // Open locked store
-        let _store = GritStore::open_locked(&store_path).unwrap();
+        let _store = GriteStore::open_locked(&store_path).unwrap();
 
         // Lock file should now exist
         assert!(lock_path.exists());
@@ -1166,10 +1166,10 @@ mod tests {
         let store_path = dir.path().join("sled");
 
         // First open succeeds
-        let _store1 = GritStore::open_locked(&store_path).unwrap();
+        let _store1 = GriteStore::open_locked(&store_path).unwrap();
 
         // Second open should fail with DbBusy
-        let result = GritStore::open_locked(&store_path);
+        let result = GriteStore::open_locked(&store_path);
         assert!(result.is_err());
         match result.unwrap_err() {
             GriteError::DbBusy(msg) => {
@@ -1186,12 +1186,12 @@ mod tests {
 
         // First open
         {
-            let _store = GritStore::open_locked(&store_path).unwrap();
+            let _store = GriteStore::open_locked(&store_path).unwrap();
             // Store is dropped here
         }
 
         // Second open should succeed after drop
-        let _store2 = GritStore::open_locked(&store_path).unwrap();
+        let _store2 = GriteStore::open_locked(&store_path).unwrap();
     }
 
     #[test]
@@ -1200,10 +1200,10 @@ mod tests {
         let store_path = dir.path().join("sled");
 
         // First open succeeds
-        let _store1 = GritStore::open_locked(&store_path).unwrap();
+        let _store1 = GriteStore::open_locked(&store_path).unwrap();
 
         // Blocking open with very short timeout should fail
-        let result = GritStore::open_locked_blocking(&store_path, Duration::from_millis(50));
+        let result = GriteStore::open_locked_blocking(&store_path, Duration::from_millis(50));
         assert!(result.is_err());
         match result.unwrap_err() {
             GriteError::DbBusy(msg) => {
@@ -1218,9 +1218,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let store_path = dir.path().join("sled");
 
-        let store = GritStore::open_locked(&store_path).unwrap();
+        let store = GriteStore::open_locked(&store_path).unwrap();
 
-        // Verify we can access GritStore methods through Deref
+        // Verify we can access GriteStore methods through Deref
         let issue_id = generate_issue_id();
         let actor = [1u8; 16];
         let event = make_event(
@@ -1234,7 +1234,7 @@ mod tests {
             },
         );
 
-        // These calls go through Deref to GritStore
+        // These calls go through Deref to GriteStore
         store.insert_event(&event).unwrap();
         let retrieved = store.get_event(&event.event_id).unwrap();
         assert!(retrieved.is_some());

--- a/crates/libgrite-core/tests/stress_store.rs
+++ b/crates/libgrite-core/tests/stress_store.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify that store operations handle concurrent access correctly.
 
-use libgrite_core::store::GritStore;
+use libgrite_core::store::GriteStore;
 use libgrite_core::types::event::{Event, EventKind};
 use libgrite_core::types::ids::{generate_actor_id, generate_issue_id};
 use libgrite_core::hash::compute_event_id;
@@ -33,7 +33,7 @@ fn create_comment_event(actor: &[u8; 16], issue_id: &[u8; 16], ts_offset: u64) -
 #[test]
 fn test_concurrent_issue_creation() {
     let dir = tempdir().unwrap();
-    let store = Arc::new(GritStore::open(dir.path()).expect("Failed to open store"));
+    let store = Arc::new(GriteStore::open(dir.path()).expect("Failed to open store"));
 
     let num_threads = 8;
     let issues_per_thread = 50;
@@ -90,7 +90,7 @@ fn test_concurrent_issue_creation() {
 #[test]
 fn test_concurrent_comments_single_issue() {
     let dir = tempdir().unwrap();
-    let store = Arc::new(GritStore::open(dir.path()).expect("Failed to open store"));
+    let store = Arc::new(GriteStore::open(dir.path()).expect("Failed to open store"));
 
     let actor = generate_actor_id();
     let issue_id = generate_issue_id();
@@ -155,7 +155,7 @@ fn test_concurrent_comments_single_issue() {
 #[test]
 fn test_concurrent_read_write() {
     let dir = tempdir().unwrap();
-    let store = Arc::new(GritStore::open(dir.path()).expect("Failed to open store"));
+    let store = Arc::new(GriteStore::open(dir.path()).expect("Failed to open store"));
 
     let actor = generate_actor_id();
     let issue_id = generate_issue_id();
@@ -240,7 +240,7 @@ fn test_concurrent_read_write() {
 #[test]
 fn test_rebuild_during_writes() {
     let dir = tempdir().unwrap();
-    let store = Arc::new(GritStore::open(dir.path()).expect("Failed to open store"));
+    let store = Arc::new(GriteStore::open(dir.path()).expect("Failed to open store"));
 
     // Create several issues first
     let actor = generate_actor_id();

--- a/crates/libgrite-git/src/chunk.rs
+++ b/crates/libgrite-git/src/chunk.rs
@@ -1,7 +1,7 @@
 //! CBOR chunk encoding/decoding for portable event storage
 //!
 //! Chunk format:
-//! - Magic: `GRITCHNK` (8 bytes)
+//! - Magic: `GRITECNK` (8 bytes)
 //! - Version: u16 (little-endian)
 //! - Codec length: u8
 //! - Codec: "cbor-v1"
@@ -16,7 +16,7 @@ use libgrite_core::types::ids::{ActorId, EventId, IssueId};
 use crate::GitError;
 
 /// Magic bytes at start of chunk
-pub const CHUNK_MAGIC: &[u8; 8] = b"GRITCHNK";
+pub const CHUNK_MAGIC: &[u8; 8] = b"GRITECNK";
 
 /// Current chunk format version
 pub const CHUNK_VERSION: u16 = 1;

--- a/crates/libgrite-git/src/lib.rs
+++ b/crates/libgrite-git/src/lib.rs
@@ -1,6 +1,6 @@
-//! Git-backed WAL and sync operations for Grit
+//! Git-backed WAL and sync operations for Grite
 //!
-//! This crate provides Git integration for Grit's event system:
+//! This crate provides Git integration for Grite's event system:
 //! - CBOR chunk encoding/decoding for portable event storage
 //! - WAL (Write-Ahead Log) operations via `refs/grite/wal`
 //! - Snapshot management via `refs/grite/snapshots/<ts>`

--- a/crates/libgrite-git/src/sync.rs
+++ b/crates/libgrite-git/src/sync.rs
@@ -14,7 +14,7 @@ use crate::wal::WalManager;
 use crate::GitError;
 
 /// Refspec for grite refs
-pub const GRIT_REFSPEC: &str = "refs/grite/*:refs/grite/*";
+pub const GRITE_REFSPEC: &str = "refs/grite/*:refs/grite/*";
 
 /// Result of a pull operation
 #[derive(Debug)]
@@ -66,7 +66,7 @@ impl SyncManager {
 
         // Fetch refs/grite/* from remote
         let mut remote = self.repo.find_remote(remote_name)?;
-        let refspecs = [GRIT_REFSPEC];
+        let refspecs = [GRITE_REFSPEC];
 
         let mut callbacks = RemoteCallbacks::new();
         callbacks.transfer_progress(|_stats| true);
@@ -107,7 +107,7 @@ impl SyncManager {
     /// Push grite refs to a remote
     pub fn push(&self, remote_name: &str) -> Result<PushResult, GitError> {
         let mut remote = self.repo.find_remote(remote_name)?;
-        let refspecs = [GRIT_REFSPEC];
+        let refspecs = [GRITE_REFSPEC];
 
         let push_error: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
         let push_error_clone = Rc::clone(&push_error);

--- a/crates/libgrite-git/src/sync.rs
+++ b/crates/libgrite-git/src/sync.rs
@@ -13,7 +13,7 @@ use libgrite_core::types::ids::ActorId;
 use crate::wal::WalManager;
 use crate::GitError;
 
-/// Refspec for grit refs
+/// Refspec for grite refs
 pub const GRIT_REFSPEC: &str = "refs/grite/*:refs/grite/*";
 
 /// Result of a pull operation
@@ -59,7 +59,7 @@ impl SyncManager {
         })
     }
 
-    /// Pull grit refs from a remote
+    /// Pull grite refs from a remote
     pub fn pull(&self, remote_name: &str) -> Result<PullResult, GitError> {
         let wal = WalManager::open(&self.git_dir)?;
         let old_head = wal.head()?;
@@ -104,7 +104,7 @@ impl SyncManager {
         })
     }
 
-    /// Push grit refs to a remote
+    /// Push grite refs to a remote
     pub fn push(&self, remote_name: &str) -> Result<PushResult, GitError> {
         let mut remote = self.repo.find_remote(remote_name)?;
         let refspecs = [GRIT_REFSPEC];

--- a/crates/libgrite-ipc/src/client.rs
+++ b/crates/libgrite-ipc/src/client.rs
@@ -156,7 +156,7 @@ pub fn try_connect(endpoint: &str) -> Option<IpcClient> {
 #[cfg(test)]
 mod tests {
     // Client tests require a running daemon or mock server
-    // These are integration tests that would be in the grit-daemon crate
+    // These are integration tests that would be in the grite-daemon crate
 
     #[test]
     fn test_timeout_config() {

--- a/crates/libgrite-ipc/src/discovery.rs
+++ b/crates/libgrite-ipc/src/discovery.rs
@@ -10,7 +10,7 @@ use crate::{IPC_SCHEMA_VERSION, PROTOCOL_NAME};
 #[derive(Archive, Serialize, Deserialize, Debug, Clone)]
 #[rkyv(derive(Debug))]
 pub struct DiscoverRequest {
-    /// Protocol name (should be "grit-ipc")
+    /// Protocol name (should be "grite-ipc")
     pub protocol: String,
     /// Minimum supported version
     pub min_version: u32,

--- a/crates/libgrite-ipc/src/lib.rs
+++ b/crates/libgrite-ipc/src/lib.rs
@@ -1,4 +1,4 @@
-//! IPC types and client for grit daemon communication
+//! IPC types and client for grite daemon communication
 //!
 //! This crate provides:
 //! - Message types for daemon communication (IpcRequest, IpcResponse, IpcCommand)

--- a/crates/libgrite-ipc/src/lib.rs
+++ b/crates/libgrite-ipc/src/lib.rs
@@ -25,7 +25,7 @@ pub use notifications::Notification;
 pub const IPC_SCHEMA_VERSION: u32 = 1;
 
 /// Protocol identifier for discovery
-pub const PROTOCOL_NAME: &str = "grit-ipc";
+pub const PROTOCOL_NAME: &str = "grite-ipc";
 
 /// Default request timeout in milliseconds
 pub const DEFAULT_TIMEOUT_MS: u64 = 10_000;

--- a/demo.sh
+++ b/demo.sh
@@ -10,7 +10,7 @@ set -e
 
 DEMO_DIR="/tmp/grit-demo"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-GRITE_BIN="${GRITE_BIN:-$SCRIPT_DIR/target/debug/grit}"
+GRITE_BIN="${GRITE_BIN:-$SCRIPT_DIR/target/debug/grite}"
 # Use --no-daemon to avoid IPC issues in demo
 GRIT="$GRITE_BIN --no-daemon"
 

--- a/demo.sh
+++ b/demo.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-DEMO_DIR="/tmp/grit-demo"
+DEMO_DIR="/tmp/grite-demo"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GRITE_BIN="${GRITE_BIN:-$SCRIPT_DIR/target/debug/grite}"
 # Use --no-daemon to avoid IPC issues in demo

--- a/demo.sh
+++ b/demo.sh
@@ -10,9 +10,9 @@ set -e
 
 DEMO_DIR="/tmp/grit-demo"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-GRIT_BIN="${GRIT_BIN:-$SCRIPT_DIR/target/debug/grit}"
+GRITE_BIN="${GRITE_BIN:-$SCRIPT_DIR/target/debug/grit}"
 # Use --no-daemon to avoid IPC issues in demo
-GRIT="$GRIT_BIN --no-daemon"
+GRIT="$GRITE_BIN --no-daemon"
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -56,15 +56,15 @@ check_dependencies() {
         exit 1
     fi
 
-    if [ ! -x "$GRIT_BIN" ]; then
-        print_error "grite binary not found at $GRIT_BIN"
+    if [ ! -x "$GRITE_BIN" ]; then
+        print_error "grite binary not found at $GRITE_BIN"
         print_info "Build grite first with: cargo build"
-        print_info "Or set GRIT_BIN environment variable"
+        print_info "Or set GRITE_BIN environment variable"
         exit 1
     fi
 
     # Stop any existing daemon to avoid IPC issues
-    "$GRIT_BIN" daemon stop 2>/dev/null || true
+    "$GRITE_BIN" daemon stop 2>/dev/null || true
 }
 
 # Step 1: Setup project

--- a/demo.sh
+++ b/demo.sh
@@ -82,7 +82,7 @@ setup_demo() {
     # Create sample Python project
     cat > greet.py << 'PYEOF'
 #!/usr/bin/env python3
-"""Simple greeting CLI - Demo project for grit"""
+"""Simple greeting CLI - Demo project for grite"""
 import argparse
 
 def main():
@@ -195,7 +195,7 @@ work_with_checkpoints() {
     print_info "2. Claude modifies the code..."
     cat > greet.py << 'PYEOF'
 #!/usr/bin/env python3
-"""Simple greeting CLI - Demo project for grit"""
+"""Simple greeting CLI - Demo project for grite"""
 import argparse
 
 def greet(name: str, style: str = "casual") -> str:

--- a/demo.sh
+++ b/demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Grit + Claude Code Demo
-# Shows how grit provides persistent memory for AI coding agents
+# Shows how grite provides persistent memory for AI coding agents
 #
 # Usage:
 #   ./demo.sh          # Interactive mode (step-by-step with pauses)
@@ -57,8 +57,8 @@ check_dependencies() {
     fi
 
     if [ ! -x "$GRIT_BIN" ]; then
-        print_error "grit binary not found at $GRIT_BIN"
-        print_info "Build grit first with: cargo build"
+        print_error "grite binary not found at $GRIT_BIN"
+        print_info "Build grite first with: cargo build"
         print_info "Or set GRIT_BIN environment variable"
         exit 1
     fi
@@ -120,7 +120,7 @@ MDEOF
     run_cmd "$GRIT init"
 
     echo ""
-    print_info "Project created with git and grit initialized"
+    print_info "Project created with git and grite initialized"
 
     wait_for_user
 }
@@ -130,13 +130,13 @@ show_agents_md() {
     print_step "STEP 2: AGENTS.md - Agent Discovery"
 
     print_info "Grit automatically created AGENTS.md for Claude Code to discover."
-    print_info "This file tells AI coding agents how to use grit for memory/tasks."
+    print_info "This file tells AI coding agents how to use grite for memory/tasks."
     echo ""
 
     run_cmd "cat AGENTS.md"
 
     echo ""
-    print_info "Claude Code will read this file and use grit for tasks/memory"
+    print_info "Claude Code will read this file and use grite for tasks/memory"
 
     wait_for_user
 }
@@ -361,12 +361,12 @@ session_resume() {
 run_doctor() {
     print_step "STEP 9: Health Checks"
 
-    print_info "Run grit doctor to check database health:"
+    print_info "Run grite doctor to check database health:"
     run_cmd "$GRIT doctor"
 
     echo ""
     print_info "Doctor checks: git repo, WAL ref, actor config, store integrity, rebuild threshold"
-    print_info "Use 'grit doctor --fix' to auto-repair issues"
+    print_info "Use 'grite doctor --fix' to auto-repair issues"
 
     wait_for_user
 }
@@ -377,14 +377,14 @@ show_summary() {
 
     echo -e "${GREEN}${BOLD}What we demonstrated:${NC}"
     echo ""
-    echo -e "  1. ${BLUE}grit init${NC} creates AGENTS.md for agent discovery"
-    echo -e "  2. Tasks created with ${BLUE}grit issue create --label agent:todo${NC}"
-    echo -e "  3. Progress tracked with ${BLUE}grit issue comment${NC} (checkpoints)"
+    echo -e "  1. ${BLUE}grite init${NC} creates AGENTS.md for agent discovery"
+    echo -e "  2. Tasks created with ${BLUE}grite issue create --label agent:todo${NC}"
+    echo -e "  3. Progress tracked with ${BLUE}grite issue comment${NC} (checkpoints)"
     echo -e "  4. Learnings stored with ${BLUE}--label memory${NC}"
-    echo -e "  5. Dependencies tracked with ${BLUE}grit issue dep${NC} (DAG + topo sort)"
-    echo -e "  6. Codebase indexed with ${BLUE}grit context${NC} (symbols + project)"
-    echo -e "  7. New sessions retrieve context via ${BLUE}grit issue list${NC}"
-    echo -e "  8. Health checks with ${BLUE}grit doctor${NC}"
+    echo -e "  5. Dependencies tracked with ${BLUE}grite issue dep${NC} (DAG + topo sort)"
+    echo -e "  6. Codebase indexed with ${BLUE}grite context${NC} (symbols + project)"
+    echo -e "  7. New sessions retrieve context via ${BLUE}grite issue list${NC}"
+    echo -e "  8. Health checks with ${BLUE}grite doctor${NC}"
     echo ""
     echo -e "${GREEN}${BOLD}Try it yourself:${NC}"
     echo ""
@@ -394,7 +394,7 @@ show_summary() {
     echo -e "${GREEN}${BOLD}Claude Code will:${NC}"
     echo ""
     echo -e "  - Read AGENTS.md automatically"
-    echo -e "  - Use grit for task tracking"
+    echo -e "  - Use grite for task tracking"
     echo -e "  - Store/retrieve memories across sessions"
     echo ""
     echo -e "${GREEN}${BOLD}Demo project location:${NC} $DEMO_DIR"

--- a/demo.sh
+++ b/demo.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Grit + Claude Code Demo
+# grite + Claude Code Demo
 # Shows how grite provides persistent memory for AI coding agents
 #
 # Usage:
@@ -129,7 +129,7 @@ MDEOF
 show_agents_md() {
     print_step "STEP 2: AGENTS.md - Agent Discovery"
 
-    print_info "Grit automatically created AGENTS.md for Claude Code to discover."
+    print_info "grite automatically created AGENTS.md for Claude Code to discover."
     print_info "This file tells AI coding agents how to use grite for memory/tasks."
     echo ""
 
@@ -257,7 +257,7 @@ store_memory() {
 demo_dependencies() {
     print_step "STEP 6: Dependencies"
 
-    print_info "Grit tracks dependencies between issues with a formal DAG."
+    print_info "grite tracks dependencies between issues with a formal DAG."
     print_info "This lets agents understand task ordering and blockers."
     echo ""
 
@@ -402,7 +402,7 @@ show_summary() {
 }
 
 show_help() {
-    echo "Grit + Claude Code Demo"
+    echo "grite + Claude Code Demo"
     echo ""
     echo "Usage: $0 [OPTIONS]"
     echo ""

--- a/demo.sh
+++ b/demo.sh
@@ -12,7 +12,7 @@ DEMO_DIR="/tmp/grit-demo"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GRITE_BIN="${GRITE_BIN:-$SCRIPT_DIR/target/debug/grite}"
 # Use --no-daemon to avoid IPC issues in demo
-GRIT="$GRITE_BIN --no-daemon"
+GRITE="$GRITE_BIN --no-daemon"
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -117,7 +117,7 @@ MDEOF
 
     echo ""
     print_info "Initializing grit..."
-    run_cmd "$GRIT init"
+    run_cmd "$GRITE init"
 
     echo ""
     print_info "Project created with git and grite initialized"
@@ -153,18 +153,18 @@ create_task() {
     echo ""
 
     # Create task and capture the issue ID
-    CREATE_OUTPUT=$($GRIT issue create --title 'Add personalized greeting styles' --body 'Add support for formal, casual, and enthusiastic greeting styles via --style flag' --label agent:todo --json)
+    CREATE_OUTPUT=$($GRITE issue create --title 'Add personalized greeting styles' --body 'Add support for formal, casual, and enthusiastic greeting styles via --style flag' --label agent:todo --json)
     # JSON output has structure: {"schema_version":1,"ok":true,"data":{"issue_id":"...","event_id":"...","wal_head":"..."}}
     TASK_ISSUE_ID=$(echo "$CREATE_OUTPUT" | jq -r '.data.issue_id // .issue_id')
 
-    print_cmd "$GRIT issue create --title 'Add personalized greeting styles' --body '...' --label agent:todo --json"
+    print_cmd "$GRITE issue create --title 'Add personalized greeting styles' --body '...' --label agent:todo --json"
     echo "$CREATE_OUTPUT" | jq '.'
 
     echo ""
     print_info "Created issue: $TASK_ISSUE_ID"
     echo ""
     print_info "Listing all issues:"
-    run_cmd "$GRIT issue list"
+    run_cmd "$GRITE issue list"
 
     wait_for_user
 }
@@ -187,7 +187,7 @@ work_with_checkpoints() {
 
     # Post plan
     print_info "1. Claude posts a plan before starting work:"
-    run_cmd "$GRIT issue comment $ISSUE_ID --body 'Plan: Add --style flag with options: formal, casual, enthusiastic. Will create greet() function with style mapping.'"
+    run_cmd "$GRITE issue comment $ISSUE_ID --body 'Plan: Add --style flag with options: formal, casual, enthusiastic. Will create greet() function with style mapping.'"
 
     echo ""
 
@@ -227,11 +227,11 @@ PYEOF
 
     # Post checkpoint
     print_info "3. Claude posts a checkpoint after completing the change:"
-    run_cmd "$GRIT issue comment $ISSUE_ID --body 'Checkpoint: Added greet() function with 3 styles. Tested: python greet.py World --style formal'"
+    run_cmd "$GRITE issue comment $ISSUE_ID --body 'Checkpoint: Added greet() function with 3 styles. Tested: python greet.py World --style formal'"
 
     echo ""
     print_info "View the issue with all comments:"
-    run_cmd "$GRIT issue show $ISSUE_ID"
+    run_cmd "$GRITE issue show $ISSUE_ID"
 
     wait_for_user
 }
@@ -244,11 +244,11 @@ store_memory() {
     print_info "Memories persist across sessions and help future agents understand the codebase."
     echo ""
 
-    run_cmd "$GRIT issue create --title '[Memory] CLI uses argparse pattern' --body 'This project uses argparse for CLI parsing. Pattern: create ArgumentParser, add_argument() for each flag, then parse_args() and use the args object.' --label memory --json"
+    run_cmd "$GRITE issue create --title '[Memory] CLI uses argparse pattern' --body 'This project uses argparse for CLI parsing. Pattern: create ArgumentParser, add_argument() for each flag, then parse_args() and use the args object.' --label memory --json"
 
     echo ""
     print_info "Memories can be queried with the 'memory' label:"
-    run_cmd "$GRIT issue list --label memory"
+    run_cmd "$GRITE issue list --label memory"
 
     wait_for_user
 }
@@ -263,26 +263,26 @@ demo_dependencies() {
 
     # Create a second task that the first depends on
     print_info "1. Creating a prerequisite task:"
-    PREREQ_OUTPUT=$($GRIT issue create --title 'Add input validation for name arg' --body 'Validate that name is non-empty and contains only valid characters' --label agent:todo --json)
+    PREREQ_OUTPUT=$($GRITE issue create --title 'Add input validation for name arg' --body 'Validate that name is non-empty and contains only valid characters' --label agent:todo --json)
     PREREQ_ID=$(echo "$PREREQ_OUTPUT" | jq -r '.data.issue_id // .issue_id')
-    print_cmd "$GRIT issue create --title 'Add input validation for name arg' --label agent:todo --json"
+    print_cmd "$GRITE issue create --title 'Add input validation for name arg' --label agent:todo --json"
     echo "$PREREQ_OUTPUT" | jq '.'
 
     echo ""
     print_info "2. Adding a dependency: greeting styles depends on input validation:"
-    run_cmd "$GRIT issue dep add $TASK_ISSUE_ID --target $PREREQ_ID --type depends_on"
+    run_cmd "$GRITE issue dep add $TASK_ISSUE_ID --target $PREREQ_ID --type depends_on"
 
     echo ""
     print_info "3. Adding a 'blocks' relationship (validation blocks greeting styles):"
-    run_cmd "$GRIT issue dep add $PREREQ_ID --target $TASK_ISSUE_ID --type blocks"
+    run_cmd "$GRITE issue dep add $PREREQ_ID --target $TASK_ISSUE_ID --type blocks"
 
     echo ""
     print_info "4. Listing dependencies for the greeting styles task:"
-    run_cmd "$GRIT issue dep list $TASK_ISSUE_ID"
+    run_cmd "$GRITE issue dep list $TASK_ISSUE_ID"
 
     echo ""
     print_info "5. Topological order shows the correct execution sequence:"
-    run_cmd "$GRIT issue dep topo --state open"
+    run_cmd "$GRITE issue dep topo --state open"
 
     echo ""
     print_info "Agents use 'dep topo' to determine which task to work on next."
@@ -301,23 +301,23 @@ demo_context() {
 
     # Index the project files
     print_info "1. Indexing project files:"
-    run_cmd "$GRIT context index"
+    run_cmd "$GRITE context index"
 
     echo ""
     print_info "2. Querying for a symbol (the greet function):"
-    run_cmd "$GRIT context query greet"
+    run_cmd "$GRITE context query greet"
 
     echo ""
     print_info "3. Showing context for a specific file:"
-    run_cmd "$GRIT context show greet.py"
+    run_cmd "$GRITE context show greet.py"
 
     echo ""
     print_info "4. Setting project-level context (architecture decisions, conventions):"
-    run_cmd "$GRIT context set 'conventions' 'Use argparse for CLI. Functions return strings, main() prints.'"
+    run_cmd "$GRITE context set 'conventions' 'Use argparse for CLI. Functions return strings, main() prints.'"
 
     echo ""
     print_info "5. Querying project context:"
-    run_cmd "$GRIT context project"
+    run_cmd "$GRITE context project"
 
     echo ""
     print_info "Agents use context to navigate unfamiliar codebases efficiently."
@@ -332,7 +332,7 @@ session_resume() {
 
     # Use the task issue ID from step 3
     print_info "Claude closes the completed task:"
-    run_cmd "$GRIT issue close $TASK_ISSUE_ID"
+    run_cmd "$GRITE issue close $TASK_ISSUE_ID"
 
     echo ""
     echo -e "${CYAN}━━━ Simulating New Session ━━━${NC}"
@@ -341,15 +341,15 @@ session_resume() {
     print_info "from AGENTS.md to restore context:"
     echo ""
 
-    run_cmd "$GRIT sync --pull --json 2>/dev/null || echo '{\"ok\":true,\"message\":\"No remote configured\"}'"
+    run_cmd "$GRITE sync --pull --json 2>/dev/null || echo '{\"ok\":true,\"message\":\"No remote configured\"}'"
 
     echo ""
     print_info "Check for open tasks:"
-    run_cmd "$GRIT issue list --state open --label agent:todo"
+    run_cmd "$GRITE issue list --state open --label agent:todo"
 
     echo ""
     print_info "Retrieve stored memories:"
-    run_cmd "$GRIT issue list --label memory"
+    run_cmd "$GRITE issue list --label memory"
 
     echo ""
     print_info "Claude can see all memories and open tasks from previous sessions!"
@@ -362,7 +362,7 @@ run_doctor() {
     print_step "STEP 9: Health Checks"
 
     print_info "Run grite doctor to check database health:"
-    run_cmd "$GRIT doctor"
+    run_cmd "$GRITE doctor"
 
     echo ""
     print_info "Doctor checks: git repo, WAL ref, actor config, store integrity, rebuild threshold"

--- a/demo.sh
+++ b/demo.sh
@@ -116,7 +116,7 @@ MDEOF
     run_cmd "git commit -q -m 'Initial commit'"
 
     echo ""
-    print_info "Initializing grit..."
+    print_info "Initializing grite..."
     run_cmd "$GRITE init"
 
     echo ""
@@ -440,7 +440,7 @@ main() {
     echo -e "${GREEN}"
     cat << 'BANNER'
     ╔════════════════════════════════════════════════════════════╗
-    ║           GRIT + CLAUDE CODE DEMO                          ║
+    ║           GRITE + CLAUDE CODE DEMO                          ║
     ║   Persistent Memory for AI Coding Agents                   ║
     ╚════════════════════════════════════════════════════════════╝
 BANNER

--- a/demo/README.md
+++ b/demo/README.md
@@ -83,7 +83,7 @@ Claude Code will:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GRIT_BIN` | `./target/debug/grite` | Path to grite binary |
+| `GRITE_BIN` | `./target/debug/grite` | Path to grite binary |
 
 ## Troubleshooting
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
-# Grit + Claude Code Demo
+# grite + Claude Code Demo
 
-This demo shows how Grit provides persistent memory for AI coding agents like Claude Code.
+This demo shows how grite provides persistent memory for AI coding agents like Claude Code.
 
 ## Quick Start
 

--- a/docs/actors.md
+++ b/docs/actors.md
@@ -20,7 +20,7 @@ Actors identify who authored an event and provide per-agent local state isolatio
 
 Actor context for a command is resolved in this order:
 
-1. `--data-dir` or `GRIT_HOME`
+1. `--data-dir` or `GRITE_HOME`
 2. `--actor <id>` (resolves to `.git/grite/actors/<id>/`)
 3. Repo default in `.git/grite/config.toml`
 4. Auto-init a new actor if none exists

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -21,7 +21,7 @@ Select exactly one issue at a time.
 
 ## Shared repo note
 
-If multiple agents share the same `.git` directory, each agent must use a separate data directory. Set `GRIT_HOME`, `--data-dir`, or `--actor <id>` so the local DB is not shared between processes.
+If multiple agents share the same `.git` directory, each agent must use a separate data directory. Set `GRITE_HOME`, `--data-dir`, or `--actor <id>` so the local DB is not shared between processes.
 
 ## Plan format
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,7 +60,7 @@
 
 ## Data directory
 
-- `GRIT_HOME` or `--data-dir` sets the local state root for this process
+- `GRITE_HOME` or `--data-dir` sets the local state root for this process
 - Default is `.git/grite/actors/<actor_id>/`
 - Each concurrent agent should use a distinct data dir
 - If a daemon owns the selected data dir, the CLI routes all commands through it and does not open the DB directly
@@ -111,7 +111,7 @@ By default, `grite init` creates or updates an `AGENTS.md` file in the repositor
 
 Actor context for a command is resolved in this order:
 
-1. `--data-dir` or `GRIT_HOME`
+1. `--data-dir` or `GRITE_HOME`
 2. `--actor <id>` (resolves to `.git/grite/actors/<id>/`)
 3. Repo default in `.git/grite/config.toml` (set by `grite actor use`)
 4. Auto-init a new actor if none exists

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ max_age_days = 7
 ### Fields
 
 - `default_actor` (optional): 16-byte hex actor ID used when no `--actor` or
-  `GRIT_HOME/--data-dir` is provided.
+  `GRITE_HOME/--data-dir` is provided.
 - `lock_policy` (optional, default `warn`): one of `off`, `warn`, or `require`.
 - `[snapshot]` (optional): local snapshot policy overrides.
   - `max_events` (optional, default 10000): create a snapshot when events since

--- a/docs/git-wal.md
+++ b/docs/git-wal.md
@@ -24,7 +24,7 @@ events/YYYY/MM/DD/<chunk>.bin
 
 Chunk files contain a small header and a portable CBOR payload:
 
-- magic: `GRITCHNK`
+- magic: `GRITECNK`
 - version: `u16`
 - codec: `cbor-v1`
 - payload: canonical CBOR array of `Event` records
@@ -81,7 +81,7 @@ events/0000.bin
 events/0001.bin
 ```
 
-Snapshots may contain multiple chunk files. Chunks use the same `GRITCHNK`
+Snapshots may contain multiple chunk files. Chunks use the same `GRITECNK`
 encoding as WAL chunks.
 
 ### Snapshot semantics

--- a/documentation/docs/agents/index.md
+++ b/documentation/docs/agents/index.md
@@ -75,7 +75,7 @@ grite actor init --label "agent-$(hostname)"
 Or set via environment:
 
 ```bash
-export GRIT_HOME=/path/to/agent/data
+export GRITE_HOME=/path/to/agent/data
 ```
 
 ### Coordinate with Locks

--- a/documentation/docs/agents/playbook.md
+++ b/documentation/docs/agents/playbook.md
@@ -36,7 +36,7 @@ Options:
 
 ```bash
 # Option 1: Environment variable
-export GRIT_HOME=/path/to/agent/data
+export GRITE_HOME=/path/to/agent/data
 
 # Option 2: Flag
 grite --data-dir /path/to/agent/data issue list --json

--- a/documentation/docs/architecture/git-wal.md
+++ b/documentation/docs/architecture/git-wal.md
@@ -45,12 +45,12 @@ tree/
 
 ## Chunk Format
 
-Events are encoded in chunks using the GRITCHNK format.
+Events are encoded in chunks using the GRITECNK format.
 
 ### Header
 
 ```
-Magic: GRITCHNK (8 bytes)
+Magic: GRITECNK (8 bytes)
 Version: 1 (u8)
 Count: number of events (u32, big-endian)
 ```
@@ -62,7 +62,7 @@ After the header, events are CBOR-encoded and concatenated.
 ### Example
 
 ```
-GRITCHNK\x01\x00\x00\x00\x03   # Header: 3 events
+GRITECNK\x01\x00\x00\x00\x03   # Header: 3 events
 [CBOR event 1]
 [CBOR event 2]
 [CBOR event 3]

--- a/documentation/docs/guides/actors.md
+++ b/documentation/docs/guides/actors.md
@@ -143,7 +143,7 @@ grite --actor e5f6a7b8 issue create --title "..."
 Set actor via environment:
 
 ```bash
-export GRIT_HOME=.git/grite/actors/e5f6a7b8/
+export GRITE_HOME=.git/grite/actors/e5f6a7b8/
 grite issue list
 ```
 
@@ -151,7 +151,7 @@ grite issue list
 
 Grite resolves actor context in this order:
 
-1. `--data-dir` or `GRIT_HOME` environment variable
+1. `--data-dir` or `GRITE_HOME` environment variable
 2. `--actor <id>` flag
 3. `default_actor` in `.git/grite/config.toml`
 4. Auto-create new actor if none exists

--- a/documentation/docs/reference/cli.md
+++ b/documentation/docs/reference/cli.md
@@ -524,7 +524,7 @@ grite daemon stop
 
 Actor context is resolved in this order:
 
-1. `--data-dir` or `GRIT_HOME`
+1. `--data-dir` or `GRITE_HOME`
 2. `--actor <id>`
 3. `default_actor` in `.git/grite/config.toml`
 4. Auto-create new actor if none exists

--- a/documentation/docs/reference/configuration.md
+++ b/documentation/docs/reference/configuration.md
@@ -213,7 +213,7 @@ key_scheme = "ed25519"
 
 For actor selection:
 
-1. `--data-dir` flag or `GRIT_HOME` environment variable
+1. `--data-dir` flag or `GRITE_HOME` environment variable
 2. `--actor` flag
 3. `default_actor` in repository config
 4. Auto-create new actor

--- a/documentation/docs/reference/environment.md
+++ b/documentation/docs/reference/environment.md
@@ -4,7 +4,7 @@ This document describes environment variables that affect grite behavior.
 
 ## Variables
 
-### GRIT_HOME
+### GRITE_HOME
 
 Override the actor data directory.
 
@@ -15,7 +15,7 @@ Override the actor data directory.
 When set, grite uses this directory for all actor data instead of the default location.
 
 ```bash
-export GRIT_HOME=/custom/path/grite/actor1
+export GRITE_HOME=/custom/path/grite/actor1
 grite issue list  # Uses data from /custom/path/grite/actor1
 ```
 
@@ -29,11 +29,11 @@ grite issue list  # Uses data from /custom/path/grite/actor1
 
 ```bash
 # Agent 1
-export GRIT_HOME=/tmp/grite/agent1
+export GRITE_HOME=/tmp/grite/agent1
 grite issue list
 
 # Agent 2
-export GRIT_HOME=/tmp/grite/agent2
+export GRITE_HOME=/tmp/grite/agent2
 grite issue list
 ```
 
@@ -90,7 +90,7 @@ export RUST_LOG=debug,libgrite_core::store=trace
 Actor context is resolved in this order (highest precedence first):
 
 1. **`--data-dir` flag** - Explicit path
-2. **`GRIT_HOME` environment variable** - Override default
+2. **`GRITE_HOME` environment variable** - Override default
 3. **`--actor` flag** - Specific actor ID
 4. **`default_actor` in config** - Repository default
 5. **Auto-create** - New actor if none exists
@@ -102,7 +102,7 @@ Actor context is resolved in this order (highest precedence first):
 grite --data-dir /custom/path issue list
 
 # Environment variable
-export GRIT_HOME=/custom/path
+export GRITE_HOME=/custom/path
 grite issue list
 
 # Flag
@@ -118,7 +118,7 @@ grite issue list  # Uses default_actor from .git/grite/config.toml
 
 ```yaml
 env:
-  GRIT_HOME: ${{ runner.temp }}/grite-${{ github.run_id }}
+  GRITE_HOME: ${{ runner.temp }}/grite-${{ github.run_id }}
 
 steps:
   - name: Initialize grite
@@ -130,7 +130,7 @@ steps:
 
 ```yaml
 variables:
-  GRIT_HOME: "${CI_PROJECT_DIR}/.grite-ci-${CI_JOB_ID}"
+  GRITE_HOME: "${CI_PROJECT_DIR}/.grite-ci-${CI_JOB_ID}"
 
 script:
   - grite actor init --label "ci-${CI_JOB_ID}"
@@ -139,10 +139,10 @@ script:
 ### Docker
 
 ```dockerfile
-ENV GRIT_HOME=/app/.grite
+ENV GRITE_HOME=/app/.grite
 
 # Or at runtime
-docker run -e GRIT_HOME=/app/.grite myimage
+docker run -e GRITE_HOME=/app/.grite myimage
 ```
 
 ## Shell Configuration
@@ -153,7 +153,7 @@ Add to `~/.bashrc` or `~/.zshrc`:
 
 ```bash
 # Custom grite home
-export GRIT_HOME="$HOME/.grite/default-actor"
+export GRITE_HOME="$HOME/.grite/default-actor"
 
 # Debug logging
 alias grite-debug='RUST_LOG=debug grite'
@@ -164,7 +164,7 @@ alias grite-debug='RUST_LOG=debug grite'
 Add to `~/.config/fish/config.fish`:
 
 ```fish
-set -x GRIT_HOME "$HOME/.grite/default-actor"
+set -x GRITE_HOME "$HOME/.grite/default-actor"
 ```
 
 ## Troubleshooting
@@ -176,7 +176,7 @@ set -x GRIT_HOME "$HOME/.grite/default-actor"
 grite actor current --json | jq
 
 # Check environment
-echo $GRIT_HOME
+echo $GRITE_HOME
 echo $RUST_LOG
 ```
 
@@ -190,8 +190,8 @@ Check actor selection precedence:
 # What's the current actor?
 grite actor current --json
 
-# Is GRIT_HOME set?
-echo $GRIT_HOME
+# Is GRITE_HOME set?
+echo $GRITE_HOME
 
 # What's the default in config?
 cat .git/grite/config.toml

--- a/documentation/docs/reference/index.md
+++ b/documentation/docs/reference/index.md
@@ -34,7 +34,7 @@ Configuration file reference:
 
 Environment variable reference:
 
-- `GRIT_HOME`
+- `GRITE_HOME`
 - `RUST_LOG`
 - Precedence rules
 

--- a/documentation/docs/stylesheets/extra.css
+++ b/documentation/docs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-/* Custom styles for Grit documentation */
+/* Custom styles for grite documentation */
 
 /* Code block styling */
 .md-typeset code {

--- a/packaging/chocolatey/tools/chocolateyuninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop'
 
-$packageName = 'grit'
+$packageName = 'grite'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $installDir = Join-Path $toolsDir $packageName
 

--- a/packaging/chocolatey/tools/chocolateyuninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyuninstall.ps1
@@ -15,4 +15,4 @@ if (Test-Path $installDir) {
   Remove-Item -Path $installDir -Recurse -Force
 }
 
-Write-Host "grit has been uninstalled."
+Write-Host "grite has been uninstalled."


### PR DESCRIPTION
### Caveats on the breaking changes

- The hash prefix change means existing context issue IDs will change
- The magic bytes change (`GRITCHNK` → `GRITECNK`) means existing git ref data won't be readable by the new code

If backward compatibility matters, these two could be reverted or made configurable