### PR TITLE
feat: sort issues by created timestamp instead of by ID

### DIFF
--- a/crates/grite-daemon/src/worker.rs
+++ b/crates/grite-daemon/src/worker.rs
@@ -291,6 +291,7 @@ fn execute_command_inner(
                 "state": format!("{:?}", s.state).to_lowercase(),
                 "labels": s.labels,
                 "assignees": s.assignees,
+                "created_ts": s.created_ts,
                 "updated_ts": s.updated_ts,
                 "comment_count": s.comment_count,
             })).collect();

--- a/crates/grite/src/commands/issue.rs
+++ b/crates/grite/src/commands/issue.rs
@@ -124,6 +124,7 @@ struct IssueSummaryJson {
     state: String,
     labels: Vec<String>,
     assignees: Vec<String>,
+    created_ts: u64,
     updated_ts: u64,
     comment_count: usize,
 }
@@ -136,6 +137,7 @@ impl From<&IssueSummary> for IssueSummaryJson {
             state: format!("{:?}", s.state).to_lowercase(),
             labels: s.labels.clone(),
             assignees: s.assignees.clone(),
+            created_ts: s.created_ts,
             updated_ts: s.updated_ts,
             comment_count: s.comment_count,
         }

--- a/crates/libgrite-core/src/export.rs
+++ b/crates/libgrite-core/src/export.rs
@@ -31,6 +31,7 @@ pub struct IssueSummaryJson {
     pub state: String,
     pub labels: Vec<String>,
     pub assignees: Vec<String>,
+    pub created_ts: u64,
     pub updated_ts: u64,
     pub comment_count: usize,
 }
@@ -43,6 +44,7 @@ impl From<&IssueSummary> for IssueSummaryJson {
             state: format!("{:?}", s.state).to_lowercase(),
             labels: s.labels.clone(),
             assignees: s.assignees.clone(),
+            created_ts: s.created_ts,
             updated_ts: s.updated_ts,
             comment_count: s.comment_count,
         }

--- a/crates/libgrite-core/src/store/mod.rs
+++ b/crates/libgrite-core/src/store/mod.rs
@@ -472,8 +472,8 @@ impl GriteStore {
             summaries.push(IssueSummary::from(&proj));
         }
 
-        // Sort by issue_id (lexicographic)
-        summaries.sort_by(|a, b| a.issue_id.cmp(&b.issue_id));
+        // Sort by creation time (oldest first)
+        summaries.sort_by_key(|s| s.created_ts);
 
         Ok(summaries)
     }

--- a/crates/libgrite-core/src/types/issue.rs
+++ b/crates/libgrite-core/src/types/issue.rs
@@ -126,6 +126,7 @@ pub struct IssueSummary {
     pub state: IssueState,
     pub labels: Vec<String>,
     pub assignees: Vec<String>,
+    pub created_ts: u64,
     pub updated_ts: u64,
     pub comment_count: usize,
 }
@@ -138,6 +139,7 @@ impl From<&IssueProjection> for IssueSummary {
             state: proj.state,
             labels: proj.labels.iter().cloned().collect(),
             assignees: proj.assignees.iter().cloned().collect(),
+            created_ts: proj.created_ts,
             updated_ts: proj.updated_ts,
             comment_count: proj.comments.len(),
         }


### PR DESCRIPTION
Since issue IDs are generated as hashes, issue sorting was effectively random from a user perspective.