### PR TITLE
feat: make context optional

### DIFF
--- a/crates/grite/Cargo.toml
+++ b/crates/grite/Cargo.toml
@@ -17,6 +17,10 @@ authors.workspace = true
 name = "grite"
 path = "src/main.rs"
 
+[features]
+default = ["context"]
+context = ["libgrite-core/context", "libgrite-cli/context", "libgrite-git/context"]
+
 [dependencies]
 libgrite-core = { path = "../libgrite-core", version = "0.5.1" }
 libgrite-git = { path = "../libgrite-git", version = "0.5.1" }

--- a/crates/grite/src/cli.rs
+++ b/crates/grite/src/cli.rs
@@ -114,6 +114,7 @@ pub enum Command {
     },
 
     /// Context store management (file/symbol indexing)
+    #[cfg(feature = "context")]
     Context {
         #[command(subcommand)]
         cmd: ContextCommand,
@@ -541,6 +542,7 @@ pub enum DepCommand {
     },
 }
 
+#[cfg(feature = "context")]
 #[derive(Clone, Subcommand)]
 pub enum ContextCommand {
     /// Index files in the repository

--- a/crates/grite/src/commands/mod.rs
+++ b/crates/grite/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod actor;
+#[cfg(feature = "context")]
 pub mod context;
 pub mod daemon;
 pub mod db;

--- a/crates/grite/src/main.rs
+++ b/crates/grite/src/main.rs
@@ -50,6 +50,7 @@ fn run_command(cli: &Cli) -> Result<(), GriteError> {
         Command::Daemon { cmd } => commands::daemon::run(cli, cmd.clone()),
         Command::Lock { cmd } => commands::lock::run(cli, cmd.clone()),
         Command::Doctor { fix } => commands::doctor::run(cli, *fix),
+        #[cfg(feature = "context")]
         Command::Context { cmd } => commands::context::run(cli, cmd.clone()),
         Command::InstallSkill { global, force } => {
             commands::install_skill::run(cli, *global, *force)

--- a/crates/grite/src/router.rs
+++ b/crates/grite/src/router.rs
@@ -107,6 +107,7 @@ pub fn should_route_through_daemon(cmd: &crate::cli::Command) -> bool {
         Command::Doctor { .. } => false,
 
         // Context commands are local-only (need filesystem access)
+        #[cfg(feature = "context")]
         Command::Context { .. } => false,
 
         // Install-skill is local-only
@@ -150,8 +151,9 @@ pub fn cli_to_ipc_command(cmd: &crate::cli::Command) -> Option<IpcCommand> {
         | Command::Daemon { .. }
         | Command::Lock { .. }
         | Command::Doctor { .. }
-        | Command::Context { .. }
         | Command::InstallSkill { .. } => None,
+        #[cfg(feature = "context")]
+        Command::Context { .. } => None,
     }
 }
 

--- a/crates/libgrite-cli/Cargo.toml
+++ b/crates/libgrite-cli/Cargo.toml
@@ -14,8 +14,9 @@ readme = "README.md"
 authors.workspace = true
 
 [features]
-default = []
+default = ["context"]
 async = ["dep:tokio"]
+context = ["libgrite-core/context"]
 
 [dependencies]
 libgrite-core = { path = "../libgrite-core", version = "0.5.1" }

--- a/crates/libgrite-cli/src/async_wrappers.rs
+++ b/crates/libgrite-cli/src/async_wrappers.rs
@@ -140,6 +140,7 @@ pub async fn rebuild_async(
 }
 
 /// Async: index context.
+#[cfg(feature = "context")]
 pub async fn context_index_async(
     ctx: &GriteContext,
     opts: ContextIndexOptions,

--- a/crates/libgrite-cli/src/lib.rs
+++ b/crates/libgrite-cli/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod actor;
 pub mod context;
+#[cfg(feature = "context")]
 pub mod context_cmd;
 pub mod daemon;
 pub mod db;

--- a/crates/libgrite-cli/src/types.rs
+++ b/crates/libgrite-cli/src/types.rs
@@ -501,6 +501,7 @@ pub struct DoctorCheckResult {
 }
 
 /// Options for context index.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ContextIndexOptions {
     pub paths: Vec<String>,
@@ -509,6 +510,7 @@ pub struct ContextIndexOptions {
 }
 
 /// Result of context index.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextIndexResult {
     pub indexed_files: usize,
@@ -516,42 +518,49 @@ pub struct ContextIndexResult {
 }
 
 /// Options for context query.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ContextQueryOptions {
     pub query: String,
 }
 
 /// Result of context query.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextQueryResult {
     pub symbols: Vec<libgrite_core::SymbolInfo>,
 }
 
 /// Options for context show.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ContextShowOptions {
     pub path: String,
 }
 
 /// Result of context show.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextShowResult {
     pub file: libgrite_core::FileContext,
 }
 
 /// Options for context project.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ContextProjectOptions {
     pub key: Option<String>,
 }
 
 /// Result of context project.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextProjectResult {
     pub entries: Vec<libgrite_core::ProjectContextEntry>,
 }
 
 /// Options for context set.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ContextSetOptions {
     pub key: String,
@@ -559,6 +568,7 @@ pub struct ContextSetOptions {
 }
 
 /// Result of context set.
+#[cfg(feature = "context")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextSetResult {
     pub key: String,

--- a/crates/libgrite-core/Cargo.toml
+++ b/crates/libgrite-core/Cargo.toml
@@ -13,6 +13,24 @@ description = "Core library for grite: event types, CRDT projections, hashing, a
 readme = "README.md"
 authors.workspace = true
 
+[features]
+default = ["context"]
+context = [
+    "dep:tree-sitter",
+    "dep:tree-sitter-language",
+    "dep:streaming-iterator",
+    "dep:tree-sitter-rust",
+    "dep:tree-sitter-python",
+    "dep:tree-sitter-typescript",
+    "dep:tree-sitter-javascript",
+    "dep:tree-sitter-go",
+    "dep:tree-sitter-java",
+    "dep:tree-sitter-c",
+    "dep:tree-sitter-cpp",
+    "dep:tree-sitter-ruby",
+    "dep:tree-sitter-elixir",
+]
+
 [dependencies]
 blake2 = { workspace = true }
 ciborium = { workspace = true }
@@ -29,19 +47,19 @@ sha2 = { workspace = true }
 ed25519-dalek = { workspace = true }
 fs2 = { workspace = true }
 regex = { workspace = true }
-tree-sitter = { workspace = true }
-tree-sitter-language = { workspace = true }
-streaming-iterator = { workspace = true }
-tree-sitter-rust = { workspace = true }
-tree-sitter-python = { workspace = true }
-tree-sitter-typescript = { workspace = true }
-tree-sitter-javascript = { workspace = true }
-tree-sitter-go = { workspace = true }
-tree-sitter-java = { workspace = true }
-tree-sitter-c = { workspace = true }
-tree-sitter-cpp = { workspace = true }
-tree-sitter-ruby = { workspace = true }
-tree-sitter-elixir = { workspace = true }
+tree-sitter = { workspace = true, optional = true }
+tree-sitter-language = { workspace = true, optional = true }
+streaming-iterator = { workspace = true, optional = true }
+tree-sitter-rust = { workspace = true, optional = true }
+tree-sitter-python = { workspace = true, optional = true }
+tree-sitter-typescript = { workspace = true, optional = true }
+tree-sitter-javascript = { workspace = true, optional = true }
+tree-sitter-go = { workspace = true, optional = true }
+tree-sitter-java = { workspace = true, optional = true }
+tree-sitter-c = { workspace = true, optional = true }
+tree-sitter-cpp = { workspace = true, optional = true }
+tree-sitter-ruby = { workspace = true, optional = true }
+tree-sitter-elixir = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/crates/libgrite-core/src/export.rs
+++ b/crates/libgrite-core/src/export.rs
@@ -174,6 +174,7 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 }
             })
         }
+        #[cfg(feature = "context")]
         EventKind::ContextUpdated {
             path,
             language,
@@ -191,6 +192,7 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 }
             })
         }
+        #[cfg(feature = "context")]
         EventKind::ProjectContextUpdated { key, value } => {
             serde_json::json!({
                 "ProjectContextUpdated": {

--- a/crates/libgrite-core/src/hash.rs
+++ b/crates/libgrite-core/src/hash.rs
@@ -127,6 +127,7 @@ pub fn kind_to_tag_and_payload(kind: &EventKind) -> (u32, ciborium::Value) {
                 Value::Text(dep_type.as_str().to_string()),
             ]),
         ),
+        #[cfg(feature = "context")]
         EventKind::ContextUpdated {
             path,
             language,
@@ -161,6 +162,7 @@ pub fn kind_to_tag_and_payload(kind: &EventKind) -> (u32, ciborium::Value) {
                 ]),
             )
         }
+        #[cfg(feature = "context")]
         EventKind::ProjectContextUpdated { key, value } => (
             14,
             Value::Array(vec![Value::Text(key.clone()), Value::Text(value.clone())]),
@@ -497,6 +499,7 @@ mod tests {
         assert_ne!(id1, id_add);
     }
 
+    #[cfg(feature = "context")]
     #[test]
     fn test_vector_13_context_updated() {
         use crate::types::event::SymbolInfo;
@@ -553,6 +556,7 @@ mod tests {
         assert_eq!(id1, id3, "Symbol order should not affect hash");
     }
 
+    #[cfg(feature = "context")]
     #[test]
     fn test_vector_14_project_context_updated() {
         let issue_id: IssueId = hex_to_id("000102030405060708090a0b0c0d0e0f").unwrap();

--- a/crates/libgrite-core/src/lib.rs
+++ b/crates/libgrite-core/src/lib.rs
@@ -22,6 +22,7 @@
 //! - **Append-only** for comments, links, attachments
 
 pub mod config;
+#[cfg(feature = "context")]
 pub mod context;
 pub mod error;
 pub mod export;
@@ -47,8 +48,11 @@ pub use lock::{resource_hash, Lock, LockCheckResult, LockPolicy, LockStatus, DEF
 pub use signing::{verify_signature, SigningError, SigningKeyPair, VerificationPolicy};
 pub use store::{DbStats, GriteStore, IssueFilter, LockedStore, RebuildStats};
 pub use types::actor::ActorConfig;
+#[cfg(feature = "context")]
 pub use types::context::{FileContext, ProjectContext, ProjectContextEntry};
-pub use types::event::{DependencyType, Event, EventKind, IssueState, SymbolInfo};
+#[cfg(feature = "context")]
+pub use types::event::SymbolInfo;
+pub use types::event::{DependencyType, Event, EventKind, IssueState};
 pub use types::ids::{generate_actor_id, generate_issue_id, hex_to_id, id_to_hex};
 pub use types::issue::{IssueProjection, IssueSummary, Version};
 pub use types::{ActorId, EventId, IssueId};

--- a/crates/libgrite-core/src/projection.rs
+++ b/crates/libgrite-core/src/projection.rs
@@ -105,6 +105,7 @@ impl IssueProjection {
                 });
             }
 
+            #[cfg(feature = "context")]
             EventKind::ContextUpdated { .. } | EventKind::ProjectContextUpdated { .. } => {
                 // Context events are handled by the context store, not issue projections
                 return Ok(());

--- a/crates/libgrite-core/src/store/mod.rs
+++ b/crates/libgrite-core/src/store/mod.rs
@@ -6,12 +6,11 @@ use std::time::{Duration, Instant};
 use fs2::FileExt;
 
 use crate::error::GriteError;
+#[cfg(feature = "context")]
 use crate::types::context::{FileContext, ProjectContextEntry};
-use crate::types::event::IssueState;
-use crate::types::event::{DependencyType, Event, EventKind};
+use crate::types::event::{DependencyType, Event, EventKind, IssueState};
 use crate::types::ids::{EventId, IssueId};
-use crate::types::issue::Version;
-use crate::types::issue::{IssueProjection, IssueSummary};
+use crate::types::issue::{IssueProjection, IssueSummary, Version};
 
 /// Default threshold for events since rebuild before recommending rebuild
 pub const DEFAULT_REBUILD_EVENTS_THRESHOLD: usize = 10000;
@@ -100,8 +99,11 @@ pub struct GriteStore {
     metadata: sled::Tree,
     dep_forward: sled::Tree,
     dep_reverse: sled::Tree,
+    #[cfg(feature = "context")]
     context_files: sled::Tree,
+    #[cfg(feature = "context")]
     context_symbols: sled::Tree,
+    #[cfg(feature = "context")]
     context_project: sled::Tree,
 }
 
@@ -116,8 +118,11 @@ impl GriteStore {
         let metadata = db.open_tree("metadata")?;
         let dep_forward = db.open_tree("dep_forward")?;
         let dep_reverse = db.open_tree("dep_reverse")?;
+        #[cfg(feature = "context")]
         let context_files = db.open_tree("context_files")?;
+        #[cfg(feature = "context")]
         let context_symbols = db.open_tree("context_symbols")?;
+        #[cfg(feature = "context")]
         let context_project = db.open_tree("context_project")?;
 
         Ok(Self {
@@ -129,8 +134,11 @@ impl GriteStore {
             metadata,
             dep_forward,
             dep_reverse,
+            #[cfg(feature = "context")]
             context_files,
+            #[cfg(feature = "context")]
             context_symbols,
+            #[cfg(feature = "context")]
             context_project,
         })
     }
@@ -233,6 +241,7 @@ impl GriteStore {
     /// Update the issue projection for an event
     fn update_projection(&self, event: &Event) -> Result<(), GriteError> {
         // Handle context events separately (they don't have issue projections)
+        #[cfg(feature = "context")]
         match &event.kind {
             EventKind::ContextUpdated {
                 path,
@@ -302,6 +311,7 @@ impl GriteStore {
     }
 
     /// Update file context (LWW per path)
+    #[cfg(feature = "context")]
     fn update_file_context(
         &self,
         event: &Event,
@@ -358,6 +368,7 @@ impl GriteStore {
     }
 
     /// Update project context (LWW per key)
+    #[cfg(feature = "context")]
     fn update_project_context(
         &self,
         event: &Event,
@@ -549,8 +560,11 @@ impl GriteStore {
         self.label_index.clear()?;
         self.dep_forward.clear()?;
         self.dep_reverse.clear()?;
+        #[cfg(feature = "context")]
         self.context_files.clear()?;
+        #[cfg(feature = "context")]
         self.context_symbols.clear()?;
+        #[cfg(feature = "context")]
         self.context_project.clear()?;
 
         // Collect all events
@@ -599,8 +613,11 @@ impl GriteStore {
         self.label_index.clear()?;
         self.dep_forward.clear()?;
         self.dep_reverse.clear()?;
+        #[cfg(feature = "context")]
         self.context_files.clear()?;
+        #[cfg(feature = "context")]
         self.context_symbols.clear()?;
+        #[cfg(feature = "context")]
         self.context_project.clear()?;
         self.events.clear()?;
 
@@ -838,6 +855,7 @@ impl GriteStore {
     // --- Context Query Methods ---
 
     /// Get file context for a specific path
+    #[cfg(feature = "context")]
     pub fn get_file_context(&self, path: &str) -> Result<Option<FileContext>, GriteError> {
         let key = context_file_key(path);
         match self.context_files.get(&key)? {
@@ -847,6 +865,7 @@ impl GriteStore {
     }
 
     /// Query symbols by name prefix
+    #[cfg(feature = "context")]
     pub fn query_symbols(&self, query: &str) -> Result<Vec<(String, String)>, GriteError> {
         let prefix = context_symbol_prefix(query);
         let mut results = Vec::new();
@@ -869,6 +888,7 @@ impl GriteStore {
     }
 
     /// List all indexed file paths
+    #[cfg(feature = "context")]
     pub fn list_context_files(&self) -> Result<Vec<String>, GriteError> {
         let mut paths = Vec::new();
         for result in self.context_files.iter() {
@@ -883,6 +903,7 @@ impl GriteStore {
     }
 
     /// Get a project context entry by key
+    #[cfg(feature = "context")]
     pub fn get_project_context(
         &self,
         key: &str,
@@ -895,6 +916,7 @@ impl GriteStore {
     }
 
     /// List all project context entries
+    #[cfg(feature = "context")]
     pub fn list_project_context(&self) -> Result<Vec<(String, ProjectContextEntry)>, GriteError> {
         let mut entries = Vec::new();
         for result in self.context_project.iter() {
@@ -1024,6 +1046,7 @@ fn parse_dep_key_suffix(key: &[u8], prefix_len: usize) -> Option<(IssueId, Depen
 
 // Context key helpers
 
+#[cfg(feature = "context")]
 fn context_file_key(path: &str) -> Vec<u8> {
     let mut key = Vec::new();
     key.extend_from_slice(b"ctx/file/");
@@ -1031,6 +1054,7 @@ fn context_file_key(path: &str) -> Vec<u8> {
     key
 }
 
+#[cfg(feature = "context")]
 fn context_symbol_prefix(name: &str) -> Vec<u8> {
     let mut key = Vec::new();
     key.extend_from_slice(b"ctx/sym/");
@@ -1038,6 +1062,7 @@ fn context_symbol_prefix(name: &str) -> Vec<u8> {
     key
 }
 
+#[cfg(feature = "context")]
 fn context_symbol_key(name: &str, path: &str) -> Vec<u8> {
     let mut key = context_symbol_prefix(name);
     key.push(b'/');
@@ -1045,6 +1070,7 @@ fn context_symbol_key(name: &str, path: &str) -> Vec<u8> {
     key
 }
 
+#[cfg(feature = "context")]
 fn context_project_key(key_name: &str) -> Vec<u8> {
     let mut key = Vec::new();
     key.extend_from_slice(b"ctx/proj/");

--- a/crates/libgrite-core/src/types/event.rs
+++ b/crates/libgrite-core/src/types/event.rs
@@ -298,25 +298,28 @@ mod tests {
             .kind_tag(),
             12
         );
-        assert_eq!(
-            EventKind::ContextUpdated {
-                path: String::new(),
-                language: String::new(),
-                symbols: vec![],
-                summary: String::new(),
-                content_hash: [0; 32]
-            }
-            .kind_tag(),
-            13
-        );
-        assert_eq!(
-            EventKind::ProjectContextUpdated {
-                key: String::new(),
-                value: String::new()
-            }
-            .kind_tag(),
-            14
-        );
+        #[cfg(feature = "context")]
+        {
+            assert_eq!(
+                EventKind::ContextUpdated {
+                    path: String::new(),
+                    language: String::new(),
+                    symbols: vec![],
+                    summary: String::new(),
+                    content_hash: [0; 32]
+                }
+                .kind_tag(),
+                13
+            );
+            assert_eq!(
+                EventKind::ProjectContextUpdated {
+                    key: String::new(),
+                    value: String::new()
+                }
+                .kind_tag(),
+                14
+            );
+        }
     }
 
     #[test]

--- a/crates/libgrite-core/src/types/mod.rs
+++ b/crates/libgrite-core/src/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod actor;
+#[cfg(feature = "context")]
 pub mod context;
 pub mod event;
 pub mod ids;

--- a/crates/libgrite-git/Cargo.toml
+++ b/crates/libgrite-git/Cargo.toml
@@ -13,6 +13,10 @@ description = "Git WAL, sync, and snapshot operations for grite"
 readme = "README.md"
 authors.workspace = true
 
+[features]
+default = ["context"]
+context = ["libgrite-core/context"]
+
 [dependencies]
 libgrite-core = { path = "../libgrite-core", version = "0.5.1" }
 git2 = { workspace = true }

--- a/crates/libgrite-ipc/Cargo.toml
+++ b/crates/libgrite-ipc/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 authors.workspace = true
 
 [dependencies]
-libgrite-core = { path = "../libgrite-core", version = "0.5.1" }
+libgrite-core = { path = "../libgrite-core", default-features = false }
 rkyv = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

Makes the [context store](https://docs.neullabs.com/grite/guides/context/#overview) feature optional via Cargo feature flags. Context—grite's distributed file/symbol index that AI agents can query to understand project structure—is still enabled by default, but can now be disabled at compile time to reduce binary size and compilation time by excluding tree-sitter and language grammar dependencies.

## Changes

### Features
- Added `context` feature flag to `grite`, `libgrite-cli`, `libgrite-core`, and `libgrite-git` crates
- Made all tree-sitter dependencies optional (12 crates: tree-sitter, streaming-iterator, and 10 language grammars)
- Context remains enabled by default for backwards compatibility

### Refactoring
- Added `#[cfg(feature = "context")]` guards to context-related CLI commands, types, store methods, event handlers, and tests
- Updated `libgrite-ipc` to use `default-features = false` for `libgrite-core`

## Files Changed

| Type | Files |
|------|-------|
| Modified | 19 |

**Key files:**
- `crates/libgrite-core/Cargo.toml` - Feature flag definition with optional tree-sitter deps
- `crates/libgrite-core/src/store/mod.rs` - Conditional context store fields and methods
- `crates/grite/src/cli.rs` - Conditional context subcommand
- `crates/libgrite-cli/src/types.rs` - Conditional context option/result types

## Test Plan

- [ ] `cargo test` - Context tests run with default features enabled
- [ ] `cargo test --no-default-features` - Tests compile and pass without context feature
- [ ] `cargo check --no-default-features` - All crates compile successfully without context
- [ ] `cargo build` - Binary builds with context enabled by default
- [ ] `cargo build --no-default-features` - Binary builds successfully without context