### PR TITLE
fix(dep topo): include created_ts and updated_ts in topological sort output

### DIFF
--- a/crates/grite-daemon/src/worker.rs
+++ b/crates/grite-daemon/src/worker.rs
@@ -942,6 +942,8 @@ fn execute_command_inner(
                         "title": s.title,
                         "state": format!("{:?}", s.state).to_lowercase(),
                         "labels": s.labels,
+                        "created_ts": s.created_ts,
+                        "updated_ts": s.updated_ts,
                     })
                 })
                 .collect();

--- a/crates/grite/src/commands/dep.rs
+++ b/crates/grite/src/commands/dep.rs
@@ -204,6 +204,8 @@ fn run_topo(cli: &Cli, state: Option<String>, label: Option<String>) -> Result<(
                 "title": s.title,
                 "state": format!("{:?}", s.state).to_lowercase(),
                 "labels": s.labels,
+                "created_ts": s.created_ts,
+                "updated_ts": s.updated_ts,
             })
         })
         .collect();


### PR DESCRIPTION
## Summary
Fixed the date display issue in `grite issue dep topo` where timestamps were showing as epoch dates instead of properly formatted dates.

## Changes
- Added `created_ts` and `updated_ts` fields to the JSON output in the `dep topo` command (both CLI and daemon)
- These timestamp fields are available from the `IssueSummary` struct returned by `topological_order()` but were not being included in the output

## Testing
- Verified `grite issue dep topo` now displays properly formatted dates in both JSON and human-readable table format
- Verified all other issue display commands already include timestamps (issue list, issue show, export, etc.)